### PR TITLE
redo default.nix to better faciliate nixosModule

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,28 +1,35 @@
-{ pkgs ? import <nixpkgs> { }
-, inputs
-, dependencyOverlays
-, nixCats ? builtins.fetchGit {
-    url = "https://github.com/BirdeeHub/nixCats-nvim";
-  }
-, ...
-}:
-let
-  # get the nixCats library with the builder function (and everything else) in it
-  utils = import nixCats;
-  # path to your new .config/nvim
+{inputs, ... }@attrs: let
+  inherit (inputs) nixpkgs; # <-- nixpkgs = inputs.nixpkgsSomething;
+  inherit (inputs.nixCats) utils;
   luaPath = ./.;
+  forEachSystem = utils.eachSystem nixpkgs.lib.platforms.all;
+  # the following extra_pkg_config contains any values
+  # which you want to pass to the config set of nixpkgs
+  # import nixpkgs { config = extra_pkg_config; inherit system; }
+  extra_pkg_config = {
+    # allowUnfree = true;
+  };
+  dependencyOverlays = /* (import ./overlays inputs) ++ */ [
+    # see :help nixCats.flake.outputs.overlays
+    # This overlay grabs all the inputs named in the format
+    # `plugins-<pluginName>`
+    # Once we add this overlay to our nixpkgs, we are able to
+    # use `pkgs.neovimPlugins`, which is a set of our plugins.
+    (utils.standardPluginOverlay inputs)
+    # add any flake overlays here.
+          (utils.standardPluginOverlay {
+            plugins-lazygit-nvim = inputs.lazygit-nvim;
+            plugins-osv-nvim = inputs.osv-nvim;
+          })
+    # when other people mess up their overlays by wrapping them with system,
+    # you may instead call this function on their overlay.
+    # it will check if it has the system in the set, and if so return the desired overlay
+    # (utils.fixSystemizedOverlay inputs.codeium.overlays
+    #   (system: inputs.codeium.overlays.${system}.default)
+    # )
+  ];
 
-  # see :help nixCats.flake.outputs.categories
-  categoryDefinitions =
-    { pkgs
-    , settings
-    , categories
-    , extra
-    , name
-    , mkPlugin
-    , ...
-    }@packageDef:
-    {
+  categoryDefinitions = { pkgs, settings, categories, extra, name, mkPlugin, ... }@packageDef: {
       lspsAndRuntimeDeps = {
         # dependencies I always use while developing
         dev = {
@@ -100,9 +107,8 @@ let
           vimPlugins.nvim-treesitter-parsers.c_sharp
         ];
       };
-    };
+  };
 
-  # see :help nixCats.flake.outputs.packageDefinitions
   packageDefinitions = {
     # These are the names of your packages
     # you can include as many as you wish.
@@ -140,22 +146,65 @@ let
         };
       };
   };
-
-  # We will build the one named nvim here and export that one.
+  # In this section, the main thing you will need to do is change the default package name
+  # to the name of the packageDefinitions entry you wish to use as the default.
   defaultPackageName = "nvim";
-  # return our package!
 in
-utils.baseBuilder luaPath
-{
-  inherit pkgs dependencyOverlays;
-}
-  categoryDefinitions
-  packageDefinitions
-  defaultPackageName
-# NOTE: or to return a set of all of them:
-# `in utils.mkAllPackages (utils.baseBuilder luaPath { inherit pkgs; } categoryDefinitions packageDefinitions defaultPackageName)`
-# NOTE: you may call .overrideNixCats on the resulting package or packages
-# to construct different packages from
-# your packageDefinitions from the resulting derivation of this expression!
-# `finalPackage.overrideNixCats { name = "aDifferentPackage"; }`
-# see :h nixCats.overriding
+  # see :help nixCats.flake.outputs.exports
+  forEachSystem (system: let
+    nixCatsBuilder = utils.baseBuilder luaPath {
+      inherit system dependencyOverlays extra_pkg_config nixpkgs;
+    } categoryDefinitions packageDefinitions;
+    defaultPackage = nixCatsBuilder defaultPackageName;
+    # this is just for using utils such as pkgs.mkShell
+    # The one used to build neovim is resolved inside the builder
+    # and is passed to our categoryDefinitions and packageDefinitions
+    pkgs = import nixpkgs { inherit system; };
+  in {
+    # this will make a package out of each of the packageDefinitions defined above
+    # and set the default package to the one passed in here.
+    packages = utils.mkAllWithDefault defaultPackage;
+
+    # choose your package for devShell
+    # and add whatever else you want in it.
+    devShells = {
+      default = pkgs.mkShell {
+        name = defaultPackageName;
+        packages = [ defaultPackage ];
+        inputsFrom = [ ];
+        shellHook = ''
+        '';
+      };
+    };
+
+  }) // (let
+    # we also export a nixos module to allow reconfiguration from configuration.nix
+    nixosModule = utils.mkNixosModules {
+      moduleNamespace = [ defaultPackageName ];
+      inherit defaultPackageName dependencyOverlays luaPath
+        categoryDefinitions packageDefinitions extra_pkg_config nixpkgs;
+    };
+    # and the same for home manager
+    homeModule = utils.mkHomeModules {
+      moduleNamespace = [ defaultPackageName ];
+      inherit defaultPackageName dependencyOverlays luaPath
+        categoryDefinitions packageDefinitions extra_pkg_config nixpkgs;
+    };
+  in {
+
+  # these outputs will be NOT wrapped with ${system}
+
+  # this will make an overlay out of each of the packageDefinitions defined above
+  # and set the default overlay to the one named here.
+  overlays = utils.makeOverlays luaPath {
+    # we pass in the things to make a pkgs variable to build nvim with later
+    inherit nixpkgs dependencyOverlays extra_pkg_config;
+    # and also our categoryDefinitions
+  } categoryDefinitions packageDefinitions defaultPackageName;
+
+  nixosModules.default = nixosModule;
+  homeModules.default = homeModule;
+
+  inherit utils nixosModule homeModule;
+  inherit (utils) templates;
+})

--- a/default.nix
+++ b/default.nix
@@ -180,7 +180,7 @@ in
   }) // (let
     # we also export a nixos module to allow reconfiguration from configuration.nix
     nixosModule = utils.mkNixosModules {
-      moduleNamespace = [ defaultPackageName ];
+      moduleNamespace = [ "ryanl-editor" ];
       inherit defaultPackageName dependencyOverlays luaPath
         categoryDefinitions packageDefinitions extra_pkg_config nixpkgs;
     };

--- a/flake.nix
+++ b/flake.nix
@@ -87,9 +87,9 @@
           pkgs = nixpkgsFor.${system};
         };
       });
-    } // {
-      nixosModules.default =
-        nixCats.utils.mkNixosModules {
+      nixosModules = forAllSystems (
+        system: {
+        default = nixCats.utils.mkNixosModules {
           defaultPackageName = "ryanl-editor";
           moduleNamespace = [ "ryanl-editor" ];
           luaPath = "${./.}";
@@ -97,11 +97,13 @@
           inherit (import ./default.nix (
               inputs
               // {
-          pkgs = nixpkgsFor.builtins.currentSystem;
+          inherit (nixpkgsFor.${system}) pkgs;
                 inherit inputs dependencyOverlays;
               }
             ))
             categoryDefinitions packageDefinitions extra_pkg_config;
         };
+	}
+      );
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -93,11 +93,11 @@
           defaultPackageName = "ryanl-editor";
           moduleNamespace = [ "ryanl-editor" ];
           luaPath = "${./.}";
-          inherit nixpkgs dependencyOverlays;
+          # inherit nixpkgs dependencyOverlays;
           inherit (import ./default.nix (
               inputs
               // {
-                inherit inputs dependencyOverlays;
+                inherit nixpkgs inputs dependencyOverlays;
               }
             ))
             categoryDefinitions packageDefinitions extra_pkg_config;

--- a/flake.nix
+++ b/flake.nix
@@ -97,7 +97,7 @@
           inherit (import ./default.nix (
               inputs
               // {
-                inherit (nixpkgs) pkgs;
+          pkgs = nixpkgsFor.builtins.currentSystem;
                 inherit inputs dependencyOverlays;
               }
             ))

--- a/flake.nix
+++ b/flake.nix
@@ -48,13 +48,6 @@
         }
       );
 
-      dependencyOverlays = # (import ./overlays inputs) ++
-        [
-          (nixCats.utils.standardPluginOverlay {
-            plugins-lazygit-nvim = inputs.lazygit-nvim;
-            plugins-osv-nvim = inputs.osv-nvim;
-          })
-        ];
     in
 
     {

--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,8 @@
         }
       );
 
+      nixCats = import ./default.nix { inherit inputs; };
+
     in
 
     {

--- a/flake.nix
+++ b/flake.nix
@@ -74,14 +74,6 @@
         };
       });
     } // {
-      nixosModules.default =
-        nixCats.utils.mkNixosModules {
-          defaultPackageName = "ryanl-editor";
-          moduleNamespace = [ "ryanl-editor" ];
-          luaPath = "${./.}";
-          # inherit nixpkgs dependencyOverlays;
-          inherit (self.packages.${builtins.currentSystem}.default)
-            categoryDefinitions packageDefinitions extra_pkg_config;
-        };
+      nixosModules.default = nixCats.nixosModules.default;
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -87,9 +87,9 @@
           pkgs = nixpkgsFor.${system};
         };
       });
-      nixosModules = forAllSystems (
-        system: {
-        default = nixCats.utils.mkNixosModules {
+    } // {
+      nixosModules.default =
+        nixCats.utils.mkNixosModules {
           defaultPackageName = "ryanl-editor";
           moduleNamespace = [ "ryanl-editor" ];
           luaPath = "${./.}";
@@ -97,13 +97,11 @@
           inherit (import ./default.nix (
               inputs
               // {
-          inherit (nixpkgsFor.${system}) pkgs;
+          pkgs = nixpkgsFor.builtins.currentSystem;
                 inherit inputs dependencyOverlays;
               }
             ))
             categoryDefinitions packageDefinitions extra_pkg_config;
         };
-	}
-      );
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -94,7 +94,12 @@
           moduleNamespace = [ "ryanl-editor" ];
           luaPath = "${./.}";
           inherit nixpkgs dependencyOverlays;
-          inherit (self.config."ryanl-editor".out.packages.default)
+          inherit (import ./default.nix (
+              inputs
+              // {
+                inherit inputs dependencyOverlays;
+              }
+            ))
             categoryDefinitions packageDefinitions extra_pkg_config;
         };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -94,7 +94,7 @@
           moduleNamespace = [ "ryanl-editor" ];
           luaPath = "${./.}";
           inherit nixpkgs dependencyOverlays;
-          inherit (self.packages.default)
+          inherit (self.config."ryanl-editor".out.packages.default)
             categoryDefinitions packageDefinitions extra_pkg_config;
         };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,8 @@
       # package.
       packages = forAllSystems (
         system: {
-          default = nixCats.packages.${system}.default;
+          ryanl-editor = nixCats.packages.${system}.default;
+          default = self.packages.${system}.ryanl-editor;
         }
       );
 

--- a/flake.nix
+++ b/flake.nix
@@ -97,7 +97,8 @@
           inherit (import ./default.nix (
               inputs
               // {
-                inherit nixpkgs inputs dependencyOverlays;
+                inherit (nixpkgs) pkgs;
+                inherit inputs dependencyOverlays;
               }
             ))
             categoryDefinitions packageDefinitions extra_pkg_config;

--- a/flake.nix
+++ b/flake.nix
@@ -94,13 +94,7 @@
           moduleNamespace = [ "ryanl-editor" ];
           luaPath = "${./.}";
           # inherit nixpkgs dependencyOverlays;
-          inherit (import ./default.nix (
-              inputs
-              // {
-          pkgs = nixpkgsFor.builtins.currentSystem;
-                inherit inputs dependencyOverlays;
-              }
-            ))
+          inherit (self.packages.${builtins.currentSystem}.default)
             categoryDefinitions packageDefinitions extra_pkg_config;
         };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -63,16 +63,7 @@
       # package.
       packages = forAllSystems (
         system: {
-          ryanl-editor =
-            import ./default.nix (
-              inputs
-              // {
-                inherit (nixpkgsFor.${system}) pkgs;
-                inherit inputs dependencyOverlays;
-              }
-            );
-
-          default = self.packages.${system}.ryanl-editor;
+          default = nixCats.packages.${system}.default;
         }
       );
 


### PR DESCRIPTION
After struggling with correctly exposing a nixosModue of the nvim build I went with BirdeeHub's template as a solution.
'nix flake init -t github:BirdeeHub/nixCats-nvim#nixExpressionFlakeOutputs'