### PR TITLE
Fix nix formatting

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -51,7 +51,7 @@ let
 
       nix = with pkgs; [
         nil
-        nixfmt-rfc-style
+        nixpkgs-fmt
       ];
 
       csharp = with pkgs; [

--- a/shell.nix
+++ b/shell.nix
@@ -68,7 +68,6 @@ in
 mkShell {
   buildInputs = [
     customNixCats
-    nixpkgs-fmt
   ];
 
   shellHook = ''


### PR DESCRIPTION
nix formatting was working in the shell environment but not in the package itself. I must have added the formatter to the shell build inputs while testing. This fix allows for nix formatting in all package definitions.